### PR TITLE
Fix tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,7 @@ jobs:
           key: node-modules-{{ checksum "yarn.lock" }}
       - run:
           name: Running tests
-          # command: yarn test
-          command: echo "No tests yet"
+          command: yarn test
       - save_cache:
           name: Save yarn cache
           key: node-modules-{{ checksum "yarn.lock" }}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.1",
     "rimble-ui": "^0.14.0",
-    "serto-ui": "^0.2.2",
+    "serto-ui": "^0.2.5",
     "styled-components": "^5.2.1",
     "swr": "^0.4.1",
     "typescript": "^4.1.3"
@@ -66,5 +66,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "jest": {
+    "transformIgnorePatterns": ["/node_modules/(?!deepdash-es|lodash-es)"]
   }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Verifiable Data Platform</title>
+    <title>Serto Schemas</title>
     <script>
       window.SERVER_CONFIG = "$ENVIRONMENT";
     </script>

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import * as ReactDOM from "react-dom";
+import { render, waitFor, screen } from "@testing-library/react";
 import { App } from "./App";
 
-it("renders without crashing", () => {
-  const div = document.createElement("div");
-  ReactDOM.render(<App />, div);
+it("renders without crashing", async () => {
+  render(<App />);
+  // If we don't wait for something, Auth0Provider performs some state update after test finishes and we get "not wrapped in act(...)" warning
+  await waitFor(() => screen.getByText("Log in to Serto Schemas"));
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import React from "react";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
-import { SelectAll } from "@rimble/icons";
 import { Auth0Provider } from "@auth0/auth0-react";
-import { GlobalStyle } from "serto-ui";
+import { GlobalStyle, SelectAll } from "serto-ui";
 
 import { config } from "./config";
 import { routes } from "./constants";

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,8 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+
+// Workaround for "For security reasons, `window.crypto` is required to run `auth0-spa-js`" Auth0 error (Auth0 expects to be run in a browser context, but in tests it's not, so we need to stub out `window.crypto`):
+(window as any).crypto = {
+  subtle: {},
+};

--- a/src/views/Auth/LoginPage.tsx
+++ b/src/views/Auth/LoginPage.tsx
@@ -76,7 +76,7 @@ export const LoginPage = (): JSX.Element => {
         width="525px"
       >
         <H2 color={colors.primary.base} mb={5} mt={7}>
-          Login to TrustAgent
+          Log in to Serto Schemas
         </H2>
         <Box width="100%">
           <Button onClick={doLogin} mb={3} width="100%">

--- a/yarn.lock
+++ b/yarn.lock
@@ -12639,12 +12639,11 @@ serialize-javascript@^5.0.1:
   dependencies:
     randombytes "^2.1.0"
 
-serto-ui@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/serto-ui/-/serto-ui-0.2.2.tgz#f2e10d3133760d19a69a58aed530b881b44408b3"
-  integrity sha512-/rCqRYdSao8qg9bMdMciOIvdb3BiyHoEWpyBRwqSJqsWowxLmM9rYVAtuVGBGeyyAR7HNzYMLms0O5qirp4iNQ==
+serto-ui@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/serto-ui/-/serto-ui-0.2.5.tgz#a1cf8eedc6a17a664c806636140a3ba43df7b714"
+  integrity sha512-yD592/7SWlVDQUQOWYNRhksTQ0KrZ5/z/5pb/rE0qylnu0kMcn/lHh8FN4UfG6YUV3T2BHjYMGy2zSTTKMDtnQ==
   dependencies:
-    "@rimble/icons" "^1.1.0"
     "@sindresorhus/slugify" "^1.1.0"
     deepdash-es "^5.3.5"
     prismjs "^1.23.0"
@@ -12654,7 +12653,7 @@ serto-ui@^0.2.2:
     swr "^0.2.2"
     typescript "^4.1.3"
     use-debounce "^3.4.3"
-    vc-schema-tools "^0.1.0"
+    vc-schema-tools "^0.1.1"
 
 serve-favicon@^2.5.0:
   version "2.5.0"
@@ -14160,10 +14159,10 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-vc-schema-tools@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/vc-schema-tools/-/vc-schema-tools-0.1.0.tgz#ddf45a8b1aab4df974e5b27edcf2006667c873c5"
-  integrity sha512-P8UtX9ZDn0kYVZ82J6A7KnH93kP9pBjLBFdPfsKr9KPdlmsW4wr6Dzmy7JZW2zv/zt2DsYsWoIrRUp0PU9FrRA==
+vc-schema-tools@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/vc-schema-tools/-/vc-schema-tools-0.1.1.tgz#90620e1f8355083259282a0027e4636b3cf70cb7"
+  integrity sha512-GUhCsAXU0WxzvZDwtZGCG09qB4lnatc13uF4ujULyCuw0mz1Uw2iXGjpdMI0bI2Bz7amm7tNIJMt+f1HEa4Yxw==
   dependencies:
     ajv "^6.12.3"
     deepdash-es "^5.3.5"


### PR DESCRIPTION
- Update to `serto-ui` version that compiles to CommonJS modules so jest doesn't break
- Workaround for `deepdash` using ES modules by adding jest `transformIgnorePatterns` to package.json so that deepdash and lodash are transformed into vanilla JS
- Workaround for Auth0 issue with testing environment lacking `window.crypto`
- Workaround for Auth0 updating state after test is over
- Enable tests in circleci config