### PR TITLE
chore: Redirect http to https

### DIFF
--- a/devops/nginx.conf
+++ b/devops/nginx.conf
@@ -16,6 +16,17 @@ server {
 
 
   location / {
+   set $https_redirect 0;
+   if ($http_x_forwarded_proto != "https") {
+     set $https_redirect 1;
+   }
+   if ($http_user_agent ~* "ELB-HealthChecker") {
+     set $https_redirect 0;
+   }
+   if ($https_redirect = 1) {
+     return 301 https://$host$request_uri;
+   }
+
     try_files $uri /index.html =404;
   }
 
@@ -27,7 +38,7 @@ server {
 
   # location @prerender {
   #       proxy_set_header X-Prerender-Token $PRERENDER_TOKEN;
-        
+
   #       set $prerender 0;
   #       if ($http_user_agent ~* "googlebot|bingbot|yandex|baiduspider|twitterbot|facebookexternalhit|rogerbot|linkedinbot|embedly|quora link preview|showyoubot|outbrain|pinterest\/0\.|pinterestbot|slackbot|vkShare|W3C_Validator") {
   #           set $prerender 1;
@@ -41,12 +52,12 @@ server {
   #       if ($uri ~* "\.(js|css|xml|less|png|jpg|jpeg|gif|pdf|doc|txt|ico|rss|zip|mp3|rar|exe|wmv|doc|avi|ppt|mpg|mpeg|tif|wav|mov|psd|ai|xls|mp4|m4a|swf|dat|dmg|iso|flv|m4v|torrent|ttf|woff|svg|eot)") {
   #           set $prerender 0;
   #       }
-        
+
   #       #resolve using Google's DNS server to force DNS resolution and prevent caching of IPs
   #       resolver 8.8.8.8;
- 
+
   #       if ($prerender = 1) {
-            
+
   #           #setting prerender as a variable forces DNS resolution since nginx caches IPs and doesnt play well with load balancing
   #           set $prerender "service.prerender.io";
   #           rewrite .* /https://$host$request_uri? break;
@@ -58,7 +69,7 @@ server {
   #       }
   #   }
 
-  location /static/ { 
+  location /static/ {
     autoindex off;
     alias /usr/share/nginx/html/static/;
   }


### PR DESCRIPTION
Uses example code from AWS elastic beanstalk docs for docker/nginx:
https://github.com/awsdocs/elastic-beanstalk-samples/blob/master/configuration-files/aws-provided/security-configuration/https-redirect/docker-sc/https-redirect-docker-sc.config